### PR TITLE
adding a redirect link for friends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 venv/
 output/
 __pycache__/
-/foundation/.cache/
+.cache/

--- a/docs/friends.md
+++ b/docs/friends.md
@@ -1,0 +1,3 @@
+# Links
+
+Dead file. Needed in path for redirect to work

--- a/docs/friends.md
+++ b/docs/friends.md
@@ -1,3 +1,3 @@
-# Links
+# Friends
 
 Dead file. Needed in path for redirect to work

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ plugins:
       post_url_format: "{slug}"
   - redirects:
       redirect_maps:
+        'friends.md': 'sponsorship/friends.md'
         'links.md': 'https://linktr.ee/pytexas'
         '2019.md': 'https://2019.pytexas.org'
         '2017.md': 'https://2017.pytexas.org'


### PR DESCRIPTION
Adding this so https://pytexas.org/friends redirects to https://pytexas.org/sponsorship/friends. It's a vanity redirect, but it makes social media images and posts nicer and shorter. 